### PR TITLE
Use GitHub Actions, misc updates

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_BIN: "bin"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
       matrix:
         os: [ macos-11, windows-2022 ]
         ruby: [ 2.5, 2.7, 3.1 ]
+    env:
+      BUNDLE_WITHOUT: development
 
     steps:
       - name: repo checkout
@@ -34,12 +36,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           rubygems: latest
           bundler: none
+          bundler-cache: true
         timeout-minutes: 5
-
-      - run: |
-          bundle config --local path vendor/bundle
-          bundle config --local without development
-
-      - run: bundle install --jobs 4 --retry 3
 
       - run: bundle exec rake ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    name: >-
+      ${{ matrix.os }} ${{ matrix.ruby }}
+
+    runs-on: ${{ matrix.os }}
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]'))
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ macos-11, windows-2022 ]
+        ruby: [ 2.5, 2.7, 3.1 ]
+
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v3
+
+      - name: load ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          rubygems: latest
+          bundler: none
+        timeout-minutes: 5
+
+      - run: |
+          bundle config --local path vendor/bundle
+          bundle config --local without development
+
+      - run: bundle install --jobs 4 --retry 3
+
+      - run: bundle exec rake ci

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ doc/
 
 # Ignore Mkdocs files
 site/
+
+.bundle/
+vendor/bundle/

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
 --require spec_helper
---require appveyor/worker

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   ExtraDetails: true
+  TargetRubyVersion: 2.5
 
 
 # Need to explicitly disable the SketchUp cops here because Rake tasks will
@@ -39,9 +40,13 @@ SketchupRequirements:
 SketchupSuggestions:
   Enabled: false
 
-
+<% if RUBY_VERSION < '2.6' %>
 Gemspec/DateAssignment: # new in 1.10
   Enabled: true
+<% else %>
+Gemspec/DeprecatedAttributeAssignment: # new in 1.31
+  Enabled: true
+<% end %>
 
 Gemspec/RequireMFA: # new in 1.23
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'appveyor-worker', '~> 0.2', require: false
   gem 'rake', '~> 12.0', require: false
   gem 'rspec', '~> 3.7', require: false
   gem 'rubocop-performance', '~> 1.11.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 group :test do
   gem 'rake', '~> 12.0', require: false
   gem 'rspec', '~> 3.7', require: false
-  gem 'rubocop-performance', '~> 1.11.0', require: false
+  gem 'rubocop-performance', '~> 1.13.0', require: false
   gem 'rubocop-rake', '~> 0.6.0', require: false
   gem 'rubocop-rspec', require: false
   gem 'simplecov', '~> 0.10', require: false

--- a/lib/rubocop/sketchup/tool_checker.rb
+++ b/lib/rubocop/sketchup/tool_checker.rb
@@ -13,11 +13,9 @@ module RuboCop
 
       private
 
-      # rubocop:disable Lint/UnusedMethodArgument
       def on_tool_class(class_node, body, body_methods)
         raise NotImplementedError, 'Implement this method'
       end
-      # rubocop:enable Lint/UnusedMethodArgument
 
       def body_methods(body)
         return [body] if body.def_type?


### PR DESCRIPTION
Use GitHub Actions with macos-11 & windows-2022 images/os's, Rubies 2.5, 2.7, & 3.1

Misc updates for RuboCop updates

Did not delete the `appveyor.yml` file.  Actions does not have any 32 bit Rubies.

Note that Actions will not run if a workflow doesn't exist in the `main` branch.

See https://github.com/MSP-Greg/rubocop-sketchup/actions/runs/2724409324

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `main`, not `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
