### PR TITLE
Fix #148 Add cop for Entity new

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -430,11 +430,12 @@ Style/EnvHome: # new in 1.29
 Style/FetchEnvVar: # new in 1.28
   Enabled: true
 
-# The `expect_no_offenses` special assertions have custom formatting directives.
-# They will however trigger this cop.
+# The `expect_no_offenses` and `expect_no_offenses` special assertions have
+# custom formatting directives. They will however trigger this cop.
 Style/FormatStringToken:
-  Exclude:
-    - spec/rubocop/sketchup/cop/requirements/ruby_core_namespace_spec.rb
+  AllowedMethods:
+    - expect_offense
+    - expect_no_offenses
 
 Style/FileEmpty: # new in 1.48
   Enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -209,6 +209,11 @@ SketchupRequirements/GlobalVariables:
   Reference: https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_requirements.md#globalvariables
   Enabled: true
 
+SketchupRequirements/InitializeEntity:
+  Description: Do not initialize SketchUp Entity objects with `new`.
+  Reference: https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_requirements.md#initializeentity
+  Enabled: true
+
 SketchupRequirements/LanguageHandlerGlobals:
   Description: Don't use other known global variables.
   Details: >-

--- a/lib/rubocop/sketchup/cop/requirements/initialize_entity.rb
+++ b/lib/rubocop/sketchup/cop/requirements/initialize_entity.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module SketchupRequirements
+      # SketchUp Entity objects (`Face`, `Edge`, `Group` etc) should not be
+      # initialized using the `new` constructor. These objects are managed by
+      # SketchUp. Instead use the `Sketchup::Entities#add_*` methods to create
+      # them.
+      class InitializeEntity < SketchUp::Cop
+
+        ENTITY_CLASSES = %i[
+          ComponentDefinition
+          ComponentInstance
+          ConstructionLine
+          ConstructionPoint
+          Dimension
+          DimensionLinear
+          DimensionRadial
+          Edge
+          Face
+          Group
+          Image
+          SectionPlane
+          Text
+          AttributeDictionaries
+          AttributeDictionary
+          Axes
+          Behavior
+          Curve
+          DefinitionList
+          Drawingelement
+          EdgeUse
+          Layer
+          LayerFolder
+          Layers
+          LineStyle
+          LineStyles
+          Loop
+          Material
+          Materials
+          Page
+          Pages
+          RenderingOptions
+          ShadowInfo
+          Style
+          Styles
+          Texture
+          Vertex
+        ].freeze
+
+        def_node_matcher :init_entity?, <<-PATTERN
+          (send (const (const nil? :Sketchup) #entity? ) :new ... )
+        PATTERN
+
+        MSG_INITIALIZE_ENTITY = 'Entity objects (Face, Edge, Group etc) are ' \
+                                'managed SketchUp. Instead of using the ' \
+                                '`new` constructor, use the ' \
+                                '`Sketchup::Entities#add_*` methods.'
+
+        def on_send(node)
+          return unless init_entity?(node)
+
+          add_offense(node, message: MSG_INITIALIZE_ENTITY)
+        end
+
+        private
+
+        def entity?(sym)
+          ENTITY_CLASSES.include?(sym)
+        end
+
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -76,6 +76,7 @@ In the following section you find all available cops:
 * [SketchupRequirements/GlobalInclude](cops_requirements.md#sketchuprequirementsglobalinclude)
 * [SketchupRequirements/GlobalMethods](cops_requirements.md#sketchuprequirementsglobalmethods)
 * [SketchupRequirements/GlobalVariables](cops_requirements.md#sketchuprequirementsglobalvariables)
+* [SketchupRequirements/InitializeEntity](cops_requirements.md#sketchuprequirementsinitializeentity)
 * [SketchupRequirements/LanguageHandlerGlobals](cops_requirements.md#sketchuprequirementslanguagehandlerglobals)
 * [SketchupRequirements/LoadPath](cops_requirements.md#sketchuprequirementsloadpath)
 * [SketchupRequirements/MinimalRegistration](cops_requirements.md#sketchuprequirementsminimalregistration)

--- a/manual/cops_requirements.md
+++ b/manual/cops_requirements.md
@@ -253,6 +253,22 @@ Note that backreferences like `$1`, `$2`, etc are not global variables.
 
 * [https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_requirements.md#globalvariables](https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_requirements.md#globalvariables)
 
+<a name='initializeentity'></a>
+## SketchupRequirements/InitializeEntity
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | No
+
+SketchUp Entity objects (`Face`, `Edge`, `Group` etc) should not be
+initialized using the `new` constructor. These objects are managed by
+SketchUp. Instead use the `Sketchup::Entities#add_*` methods to create
+them.
+
+### References
+
+* [https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_requirements.md#initializeentity](https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_requirements.md#initializeentity)
+
 <a name='languagehandlerglobals'></a>
 ## SketchupRequirements/LanguageHandlerGlobals
 

--- a/spec/rubocop/cop/sketchup_requirements/initialize_entity_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/initialize_entity_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RuboCop::Cop::SketchupRequirements::InitializeEntity do
+
+  subject(:cop) { described_class.new }
+
+  RuboCop::Cop::SketchupRequirements::InitializeEntity::ENTITY_CLASSES.each do |keyword|
+    it "registers an offense when using `Sketchup::#{keyword}.new`" do
+      expect_offense(<<~RUBY, keyword: keyword)
+        Sketchup::%{keyword}.new
+        ^^^^^^^^^^^{keyword}^^^^ Entity objects (Face, Edge, Group etc) are managed SketchUp. Instead of using the `new` constructor, use the `Sketchup::Entities#add_*` methods.
+      RUBY
+    end
+
+    it "registers an offense when using `Sketchup::#{keyword}.new(0)`" do
+      expect_offense(<<~RUBY, keyword: keyword)
+        Sketchup::%{keyword}.new(0)
+        ^^^^^^^^^^^{keyword}^^^^^^^ Entity objects (Face, Edge, Group etc) are managed SketchUp. Instead of using the `new` constructor, use the `Sketchup::Entities#add_*` methods.
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Work in progress.

My node matcher (`(send (const (const nil? :Sketchup) :Face) :new _)`) doesn't seem to catch anything.

For now it should catch `Sketchup::Face.new` and skip `Edge` and `Group`, but all 3 tests give identical results.

```
Failures:

  1) RuboCop::Cop::SketchupRequirements::InitEntity registers an offense when using `Sketchup::Edge.new`
     Failure/Error:
       expect_offense(<<~RUBY)
         Sketchup::Edge.new
         ^^^^^^^^^^^^^^^^^^ Entity objects (Face, Edge, Group etc) are managed SketchUp. Instead of using the `new` constructor, use the `Sketchup::Entities#add_*` methods.
       RUBY

       Diff:
       @@ -1,3 +1,2 @@
        Sketchup::Edge.new
       -^^^^^^^^^^^^^^^^^^ Entity objects (Face, Edge, Group etc) are managed SketchUp. Instead of using the `new` constructor, use the `Sketchup::Entities#add_*` methods.

     # ./spec/rubocop/cop/sketchup_requirements/init_entity_spec.rb:17:in `block (2 levels) in <top (required)>'

  2) RuboCop::Cop::SketchupRequirements::InitEntity registers an offense when using `Sketchup::Group.new`
     Failure/Error:
       expect_offense(<<~RUBY)
         Sketchup::Group.new
         ^^^^^^^^^^^^^^^^^^^ Entity objects (Face, Edge, Group etc) are managed SketchUp. Instead of using the `new` constructor, use the `Sketchup::Entities#add_*` methods.
       RUBY

       Diff:
       @@ -1,3 +1,2 @@
        Sketchup::Group.new
       -^^^^^^^^^^^^^^^^^^^ Entity objects (Face, Edge, Group etc) are managed SketchUp. Instead of using the `new` constructor, use the `Sketchup::Entities#add_*` methods.

     # ./spec/rubocop/cop/sketchup_requirements/init_entity_spec.rb:24:in `block (2 levels) in <top (required)>'

  3) RuboCop::Cop::SketchupRequirements::InitEntity registers an offense when using `Sketchup::Face.new`
     Failure/Error:
       expect_offense(<<~RUBY)
         Sketchup::Face.new
         ^^^^^^^^^^^^^^^^^^ Entity objects (Face, Edge, Group etc) are managed SketchUp. Instead of using the `new` constructor, use the `Sketchup::Entities#add_*` methods.
       RUBY

       Diff:
       @@ -1,3 +1,2 @@
        Sketchup::Face.new
       -^^^^^^^^^^^^^^^^^^ Entity objects (Face, Edge, Group etc) are managed SketchUp. Instead of using the `new` constructor, use the `Sketchup::Entities#add_*` methods.
```

I'm suspecting a syntax issue, but I'm not sure. @thomthom, can you have a look?
