### PR TITLE
# Fix 144 Add cop warning for sleep

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -365,6 +365,14 @@ SketchupSuggestions/SketchupFindSupportFile:
   Reference: https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_suggestions.md#sketchupfindsupportfile
   Enabled: true
 
+SketchupSuggestions/Sleep:
+  Description: Avoid kernel `sleep` as it freezes up SketchUp.
+  Details: >-
+             Prefer `UI.start_timer` or a callback from the resource you are
+             waiting for.
+  Reference: https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_suggestions.md#sleep
+  Enabled: true
+
 SketchupSuggestions/ToolDrawingBounds:
   Description: >-
                  When drawing to the viewport implement `getExtents` so drawn

--- a/lib/rubocop/sketchup/cop/suggestions/sleep.rb
+++ b/lib/rubocop/sketchup/cop/suggestions/sleep.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module SketchupSuggestions
+      # Avoid kernel `sleep` as it freezes up SketchUp.
+      # Prefer `UI.start_timer` or a callback from the resource you are waiting
+      # for.
+      class Sleep < SketchUp::Cop
+        MSG = '`sleep` freezes up SketchUp. Prefer `UI.start_timer` or a ' \
+              'callback for the resource you are waiting for.'
+
+        def_node_matcher :sleep?, <<-PATTERN
+          (send {(const nil? :Kernel) nil?} :sleep ...)
+        PATTERN
+
+        def on_send(node)
+          return unless sleep?(node)
+
+          add_offense(node, message: MSG)
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -98,6 +98,7 @@ In the following section you find all available cops:
 * [SketchupSuggestions/MonkeyPatchedApi](cops_suggestions.md#sketchupsuggestionsmonkeypatchedapi)
 * [SketchupSuggestions/OperationName](cops_suggestions.md#sketchupsuggestionsoperationname)
 * [SketchupSuggestions/SketchupFindSupportFile](cops_suggestions.md#sketchupsuggestionssketchupfindsupportfile)
+* [SketchupSuggestions/Sleep](cops_suggestions.md#sketchupsuggestionssleep)
 * [SketchupSuggestions/ToolDrawingBounds](cops_suggestions.md#sketchupsuggestionstooldrawingbounds)
 * [SketchupSuggestions/ToolInvalidate](cops_suggestions.md#sketchupsuggestionstoolinvalidate)
 * [SketchupSuggestions/ToolUserInput](cops_suggestions.md#sketchupsuggestionstooluserinput)

--- a/manual/cops_suggestions.md
+++ b/manual/cops_suggestions.md
@@ -247,6 +247,21 @@ control.
 
 * [https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_suggestions.md#sketchupfindsupportfile](https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_suggestions.md#sketchupfindsupportfile)
 
+<a name='sleep'></a>
+## SketchupSuggestions/Sleep
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | No
+
+Avoid kernel `sleep` as it freezes up SketchUp.
+Prefer `UI.start_timer` or a callback from the resource you are waiting
+for.
+
+### References
+
+* [https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_suggestions.md#sleep](https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_suggestions.md#sleep)
+
 <a name='tooldrawingbounds'></a>
 ## SketchupSuggestions/ToolDrawingBounds
 

--- a/spec/rubocop/cop/sketchup_suggestions/sleep_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/sleep_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RuboCop::Cop::SketchupSuggestions::Sleep do
+
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense when using kernel `sleep`' do
+    expect_offense(<<~RUBY)
+      sleep
+      ^^^^^ `sleep` freezes up SketchUp. [...]
+    RUBY
+  end
+
+  it 'registers an offense when using kernel `sleep(1)`' do
+    expect_offense(<<~RUBY)
+      sleep(1)
+      ^^^^^^^^ `sleep` freezes up SketchUp. [...]
+    RUBY
+  end
+
+  it 'registers an offense when using kernel `sleep(0.5)`' do
+    expect_offense(<<~RUBY)
+      sleep(0.5)
+      ^^^^^^^^^^ `sleep` freezes up SketchUp. [...]
+    RUBY
+  end
+
+  it 'registers an offense when using kernel `Kernel.sleep(0.5)`' do
+    expect_offense(<<~RUBY)
+      Kernel.sleep(0.5)
+      ^^^^^^^^^^^^^^^^^ `sleep` freezes up SketchUp. [...]
+    RUBY
+  end
+
+  it 'does not registers an offense when using `SomeClass.sleep`' do
+    expect_no_offenses(<<~RUBY)
+      SomeClass.sleep
+    RUBY
+  end
+
+  it 'does not registers an offense when using custom `object.sleep`' do
+    expect_no_offenses(<<~RUBY)
+      object.sleep
+    RUBY
+  end
+end


### PR DESCRIPTION
Add suggestion cop against `sleep` as it freezes up SketchUp.

Mostly unsure how to best phrase the messages/documentation.