### PR TITLE
Command title and description

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -299,6 +299,11 @@ SketchupSuggestions/AddGroup:
   Reference: https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_suggestions.md#addgroup
   Enabled: true
 
+SketchupSuggestions/CommandTitle:
+  Description: Use title case for command titles.
+  Reference: https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_suggestions.md#commandtitle
+  Enabled: true
+
 SketchupSuggestions/Compatibility:
   Description: Incompatible feature with target SketchUp version.
   Reference: https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_suggestions.md#compatibility

--- a/lib/rubocop/sketchup/cop/suggestions/command_title.rb
+++ b/lib/rubocop/sketchup/cop/suggestions/command_title.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module SketchupSuggestions
+      # SketchUp command titles should be in title case, e.g. "Make Component"
+      # and "Follow Me".
+      #
+      # In English, capitalize the first letter of each word. Other languages
+      # may have different rules.
+      class CommandTitle < SketchUp::Cop
+
+        def_node_matcher :init_entity?, <<-PATTERN
+          (send (const (const nil? :UI) :Command ) :new ... )
+        PATTERN
+
+        MESSAGE = 'Use title case in command titles. '\
+                  'In English, capitalize the first letter of each word.'
+
+        def on_send(node)
+          return unless init_entity?(node)
+          return if title_case?(node.arguments.first.str_content)
+
+          add_offense(node, message: MESSAGE)
+        end
+
+        private
+
+        # REVIEW: Extract to where they can be re-used?
+        def title_case?(text)
+          text == title_case(text)
+        end
+
+        def title_case(text)
+          text.gsub(/^(.)/) { ::Regexp.last_match(1).upcase }
+              .gsub(/\ (.)/) { " #{::Regexp.last_match(1).upcase}" }
+              .gsub(/-(.)/) { "-#{::Regexp.last_match(1).upcase}" }
+              .gsub(/(\.)$/, '')
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/sketchup/cop/suggestions/command_title.rb
+++ b/lib/rubocop/sketchup/cop/suggestions/command_title.rb
@@ -37,16 +37,8 @@ module RuboCop
 
         # Capitalize the worst letter of each word (including after a hyphen).
         def title_case(text)
-          ### text.gsub(/\b\w/, &:capitalize)
-
           # Capitalize the first letter of the string, the first letter after
           # each space and first letter after each hyphen.
-          #
-          # This code has an identical result as the commented out line above
-          # except that the above line gives false positives for the cop
-          # which is impossible as they both act fucking identically when tested
-          # separetely.
-          # Fuck the whole fucking universe.
           text.gsub(/^(.)/) { ::Regexp.last_match(1).upcase }
               .gsub(/\ (.)/) { " #{::Regexp.last_match(1).upcase}" }
               .gsub(/-(.)/) { "-#{::Regexp.last_match(1).upcase}" }

--- a/lib/rubocop/sketchup/cop/suggestions/command_title.rb
+++ b/lib/rubocop/sketchup/cop/suggestions/command_title.rb
@@ -28,15 +28,28 @@ module RuboCop
         private
 
         # REVIEW: Extract to where they can be re-used?
+
+        # Test if string is in title case
+        # (first letter of each word capitalized and no trailing period.)
         def title_case?(text)
-          text == title_case(text)
+          text == title_case(text) && text[-1] != '.'
         end
 
+        # Capitalize the worst letter of each word (including after a hyphen).
         def title_case(text)
+          ### text.gsub(/\b\w/, &:capitalize)
+
+          # Capitalize the first letter of the string, the first letter after
+          # each space and first letter after each hyphen.
+          #
+          # This code has an identical result as the commented out line above
+          # except that the above line gives false positives for the cop
+          # which is impossible as they both act fucking identically when tested
+          # separetely.
+          # Fuck the whole fucking universe.
           text.gsub(/^(.)/) { ::Regexp.last_match(1).upcase }
               .gsub(/\ (.)/) { " #{::Regexp.last_match(1).upcase}" }
               .gsub(/-(.)/) { "-#{::Regexp.last_match(1).upcase}" }
-              .gsub(/(\.)$/, '')
         end
       end
     end

--- a/lib/rubocop/sketchup/cop/suggestions/command_title.rb
+++ b/lib/rubocop/sketchup/cop/suggestions/command_title.rb
@@ -19,6 +19,7 @@ module RuboCop
 
         def on_send(node)
           return unless init_entity?(node)
+          return if node.arguments.first.str_content.nil?
           return if title_case?(node.arguments.first.str_content)
 
           add_offense(node, message: MESSAGE)

--- a/lib/rubocop/sketchup/cop/suggestions/command_title.rb
+++ b/lib/rubocop/sketchup/cop/suggestions/command_title.rb
@@ -28,20 +28,15 @@ module RuboCop
         private
 
         # REVIEW: Extract to where they can be re-used?
-
-        # Test if string is in title case
-        # (first letter of each word capitalized and no trailing period.)
         def title_case?(text)
-          text == title_case(text) && text[-1] != '.'
+          text == title_case(text)
         end
 
-        # Capitalize the worst letter of each word (including after a hyphen).
         def title_case(text)
-          # Capitalize the first letter of the string, the first letter after
-          # each space and first letter after each hyphen.
           text.gsub(/^(.)/) { ::Regexp.last_match(1).upcase }
               .gsub(/\ (.)/) { " #{::Regexp.last_match(1).upcase}" }
               .gsub(/-(.)/) { "-#{::Regexp.last_match(1).upcase}" }
+              .gsub(/(\.)$/, '')
         end
       end
     end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -91,6 +91,7 @@ In the following section you find all available cops:
 #### Department [SketchupSuggestions](cops_suggestions.md)
 
 * [SketchupSuggestions/AddGroup](cops_suggestions.md#sketchupsuggestionsaddgroup)
+* [SketchupSuggestions/CommandTitle](cops_suggestions.md#sketchupsuggestionscommandtitle)
 * [SketchupSuggestions/Compatibility](cops_suggestions.md#sketchupsuggestionscompatibility)
 * [SketchupSuggestions/DynamicComponentInternals](cops_suggestions.md#sketchupsuggestionsdynamiccomponentinternals)
 * [SketchupSuggestions/FileEncoding](cops_suggestions.md#sketchupsuggestionsfileencoding)

--- a/manual/cops_suggestions.md
+++ b/manual/cops_suggestions.md
@@ -40,6 +40,23 @@ face2 = group.entities.add_face(points2)
 
 * [https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_suggestions.md#addgroup](https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_suggestions.md#addgroup)
 
+<a name='commandtitle'></a>
+## SketchupSuggestions/CommandTitle
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | No
+
+SketchUp command titles should be in title case, e.g. "Make Component"
+and "Follow Me".
+
+In English, capitalize the first letter of each word. Other languages
+may have different rules.
+
+### References
+
+* [https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_suggestions.md#commandtitle](https://github.com/SketchUp/rubocop-sketchup/tree/main/manual/cops_suggestions.md#commandtitle)
+
 <a name='compatibility'></a>
 ## SketchupSuggestions/Compatibility
 

--- a/spec/rubocop/cop/sketchup_suggestions/command_title_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/command_title_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RuboCop::Cop::SketchupSuggestions::CommandTitle do
+
+  subject(:cop) { described_class.new }
+
+  bad_capitalization = [
+    'text',
+    'text text',
+    'Text text',
+    'text Text',
+    'Text.',
+    'Text Text.',
+    'Text text.',
+    'text 2-Point',
+    'text 2-point'
+  ]
+
+  bad_capitalization.each do |keyword|
+    it "registers an offense when using UI::Command.new(\"#{keyword}\")" do
+      expect_offense(<<~RUBY, keyword: keyword)
+        UI::Command.new("%{keyword}")
+        ^^^^^^^^^^^^^^^^^^{keyword}^^ Use title case in command titles. [...]
+      RUBY
+    end
+
+    # TODO: Add for setter methods.
+    # Can we test by how a local variable was defined? Or only by its name?
+    #
+    # command = UI::Command.new("Test")
+    # command.menu_text = "%{keyword}"
+    #
+    # menu.add_item("%{keyword}")
+  end
+
+  good_capitalization = [
+    'Text',
+    'Text Text',
+    'Text 2-Point',
+    '文本'
+  ]
+
+  good_capitalization.each do |keyword|
+    it "does not register an offense when using UI::Command.new(\"#{keyword}\")" do
+      expect_no_offenses(<<~RUBY, keyword: keyword)
+        UI::Command.new("%{keyword}")
+      RUBY
+    end
+  end
+
+end

--- a/spec/rubocop/cop/sketchup_suggestions/command_title_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/command_title_spec.rb
@@ -50,4 +50,10 @@ describe RuboCop::Cop::SketchupSuggestions::CommandTitle do
     end
   end
 
+  it 'does not register an offense when using UI::Command.new(variable)' do
+    expect_no_offenses(<<~RUBY)
+      UI::Command.new(variable)
+    RUBY
+  end
+
 end


### PR DESCRIPTION
Adding cop for checking that command titles are in title case.

Not sure if #145 should be split up and sentence case for the statusbar should be logged as a separate issue.