### PR TITLE
Fix build error using RuboCop 1.49+

### DIFF
--- a/spec/rubocop/cop/sketchup_bugs/material_name_spec.rb
+++ b/spec/rubocop/cop/sketchup_bugs/material_name_spec.rb
@@ -2,13 +2,11 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupBugs::MaterialName do
+describe RuboCop::Cop::SketchupBugs::MaterialName, :config do
 
   context 'when using material.name=' do
 
     context 'affected SketchUp versions' do
-
-      subject(:cop) { described_class.new(config) }
 
       let(:config) do
         sketchup_version_config('SketchUp 2016')
@@ -39,10 +37,7 @@ describe RuboCop::Cop::SketchupBugs::MaterialName do
 
     end # context
 
-
     context 'unaffected SketchUp versions' do
-
-      subject(:cop) { described_class.new(config) }
 
       let(:config) do
         sketchup_version_config('SketchUp 2018')

--- a/spec/rubocop/cop/sketchup_bugs/render_mode_spec.rb
+++ b/spec/rubocop/cop/sketchup_bugs/render_mode_spec.rb
@@ -2,11 +2,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupBugs::RenderMode do
+describe RuboCop::Cop::SketchupBugs::RenderMode, :config do
 
   context 'affected SketchUp versions' do
-
-    subject(:cop) { described_class.new(config) }
 
     let(:config) do
       sketchup_version_config('SketchUp 2018')
@@ -44,10 +42,7 @@ describe RuboCop::Cop::SketchupBugs::RenderMode do
 
   end # context
 
-
   context 'unaffected SketchUp versions' do
-
-    subject(:cop) { described_class.new(config) }
 
     let(:config) do
       sketchup_version_config('SketchUp 2014')

--- a/spec/rubocop/cop/sketchup_bugs/uniform_scaling_spec.rb
+++ b/spec/rubocop/cop/sketchup_bugs/uniform_scaling_spec.rb
@@ -2,11 +2,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupBugs::UniformScaling do
+describe RuboCop::Cop::SketchupBugs::UniformScaling, :config do
 
   context 'affected SketchUp versions' do
-
-    subject(:cop) { described_class.new(config) }
 
     let(:config) do
       sketchup_version_config('SketchUp 2016')
@@ -44,10 +42,7 @@ describe RuboCop::Cop::SketchupBugs::UniformScaling do
 
   end # context
 
-
   context 'unaffected SketchUp versions' do
-
-    subject(:cop) { described_class.new(config) }
 
     let(:config) do
       sketchup_version_config('SketchUp 2018')

--- a/spec/rubocop/cop/sketchup_deprecations/add_separator_to_menu_spec.rb
+++ b/spec/rubocop/cop/sketchup_deprecations/add_separator_to_menu_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupDeprecations::AddSeparatorToMenu do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupDeprecations::AddSeparatorToMenu, :config do
 
   it 'registers an offense for add_separator_to_menus' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_deprecations/operation_next_transparent_spec.rb
+++ b/spec/rubocop/cop/sketchup_deprecations/operation_next_transparent_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupDeprecations::OperationNextTransparent do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupDeprecations::OperationNextTransparent, :config do
 
   it 'registers an offense for start_operation third argument' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_deprecations/require_all_spec.rb
+++ b/spec/rubocop/cop/sketchup_deprecations/require_all_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupDeprecations::RequireAll do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupDeprecations::RequireAll, :config do
 
   it 'registers an offense for require_all' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_deprecations/set_texture_projection_spec.rb
+++ b/spec/rubocop/cop/sketchup_deprecations/set_texture_projection_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupDeprecations::SetTextureProjection do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupDeprecations::SetTextureProjection, :config do
 
   it 'registers an offense for calling set_texture_projection' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_deprecations/show_ruby_panel_spec.rb
+++ b/spec/rubocop/cop/sketchup_deprecations/show_ruby_panel_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupDeprecations::ShowRubyPanel do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupDeprecations::ShowRubyPanel, :config do
 
   it 'registers an offense for show_ruby_panel' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_deprecations/sketchup_set_spec.rb
+++ b/spec/rubocop/cop/sketchup_deprecations/sketchup_set_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupDeprecations::SketchupSet do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupDeprecations::SketchupSet, :config do
 
   it 'registers an offense for Sketchup::Set.new' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_performance/openssl_spec.rb
+++ b/spec/rubocop/cop/sketchup_performance/openssl_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupPerformance::OpenSSL do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupPerformance::OpenSSL, :config do
 
   it 'registers an offense for use of OpenSSL' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_performance/operation_disable_ui_spec.rb
+++ b/spec/rubocop/cop/sketchup_performance/operation_disable_ui_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupPerformance::OperationDisableUI do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupPerformance::OperationDisableUI, :config do
 
   it 'does not register an offense when starting an operation and disabling the UI' do
     expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_performance/selection_bulk_changes_spec.rb
+++ b/spec/rubocop/cop/sketchup_performance/selection_bulk_changes_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupPerformance::SelectionBulkChanges do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupPerformance::SelectionBulkChanges, :config do
 
   it 'registers an offense for use of selection.add within each loop' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_performance/type_check_spec.rb
+++ b/spec/rubocop/cop/sketchup_performance/type_check_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupPerformance::TypeCheck do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupPerformance::TypeCheck, :config do
 
   it 'registers an offense for type checking by string comparison using ==' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_performance/typename_spec.rb
+++ b/spec/rubocop/cop/sketchup_performance/typename_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupPerformance::Typename do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupPerformance::Typename, :config do
 
   it 'registers an offense for use of Sketchup::Entity#typename' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_requirements/api_namespace_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/api_namespace_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::ApiNamespace do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::ApiNamespace, :config do
 
   described_class::NAMESPACES.each do |var|
 

--- a/spec/rubocop/cop/sketchup_requirements/debug_mode_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/debug_mode_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::DebugMode do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::DebugMode, :config do
 
   it 'registers an offense when using `Sketchup#debug_mode`' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_requirements/exit_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/exit_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::Exit do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::Exit, :config do
 
   it 'registers an offense for exit' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_requirements/extension_namespace_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/extension_namespace_spec.rb
@@ -4,8 +4,6 @@ require 'spec_helper'
 
 describe RuboCop::Cop::SketchupRequirements::ExtensionNamespace, :config do
 
-  subject(:cop) { described_class.new(config) }
-
   it 'registers an offense for multiple top level namespaces' do
     expect_offense(<<~RUBY)
       module Example

--- a/spec/rubocop/cop/sketchup_requirements/gem_install_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/gem_install_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::GemInstall do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::GemInstall, :config do
 
   it 'registers an offense for Gem.install' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_requirements/get_extension_license_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/get_extension_license_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::GetExtensionLicense do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::GetExtensionLicense, :config do
 
   context 'string literal extension GUID' do
 

--- a/spec/rubocop/cop/sketchup_requirements/global_constants_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/global_constants_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::GlobalConstants do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::GlobalConstants, :config do
 
   it 'registers an offense for global constants' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_requirements/global_include_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/global_include_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::GlobalInclude do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::GlobalInclude, :config do
 
   it 'registers an offense for global include' do
     expect_offense(<<~RUBY)
@@ -21,7 +19,6 @@ describe RuboCop::Cop::SketchupRequirements::GlobalInclude do
       end
     RUBY
   end
-
 
   it 'does not register an offense for include in namespaced module' do
     expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_requirements/global_methods_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/global_methods_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::GlobalMethods do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::GlobalMethods, :config do
 
   it 'registers an offense for global methods' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_requirements/global_variables_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/global_variables_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::GlobalVariables do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::GlobalVariables, :config do
 
   it 'registers an offense for $custom' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_requirements/initialize_entity_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/initialize_entity_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::InitializeEntity do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::InitializeEntity, :config do
 
   RuboCop::Cop::SketchupRequirements::InitializeEntity::ENTITY_CLASSES.each do |keyword|
     it "registers an offense when using `Sketchup::#{keyword}.new`" do

--- a/spec/rubocop/cop/sketchup_requirements/language_handler_globals_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/language_handler_globals_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::LanguageHandlerGlobals do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::LanguageHandlerGlobals, :config do
 
   described_class::LH_GLOBALS.each do |var|
 

--- a/spec/rubocop/cop/sketchup_requirements/load_path_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/load_path_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::LoadPath do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::LoadPath, :config do
 
   it 'registers an offense when setting $LOAD_PATH' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_requirements/minimal_registration_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/minimal_registration_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::MinimalRegistration do
-
-  subject(:cop) { described_class.new(config) }
+describe RuboCop::Cop::SketchupRequirements::MinimalRegistration, :config do
 
   # Based on file_name_spec.rb
   let(:config) do

--- a/spec/rubocop/cop/sketchup_requirements/observers_start_operation_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/observers_start_operation_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::ObserversStartOperation do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::ObserversStartOperation, :config do
 
   it 'does not register an offense for not starting an operation' do
     expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_requirements/register_extension_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/register_extension_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::RegisterExtension do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::RegisterExtension, :config do
 
   it 'does not register an offense for extension set to load by default' do
     expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_requirements/ruby_core_namespace_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/ruby_core_namespace_spec.rb
@@ -2,12 +2,10 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::RubyCoreNamespace do
+describe RuboCop::Cop::SketchupRequirements::RubyCoreNamespace, :config do
 
   namespace_types = %w[class module].freeze
   mutators = %w[include extend].freeze
-
-  subject(:cop) { described_class.new }
 
   described_class::NAMESPACES.each do |var|
 

--- a/spec/rubocop/cop/sketchup_requirements/ruby_stdlib_namespace_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/ruby_stdlib_namespace_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::RubyStdLibNamespace do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupRequirements::RubyStdLibNamespace, :config do
 
   described_class::NAMESPACES_RUBY_STDLIB.each do |namespace|
 

--- a/spec/rubocop/cop/sketchup_requirements/shipped_extensions_namespace_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/shipped_extensions_namespace_spec.rb
@@ -2,11 +2,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::ShippedExtensionsNamespace do
+describe RuboCop::Cop::SketchupRequirements::ShippedExtensionsNamespace, :config do
 
   namespace_types = %w[class module].freeze
-
-  subject(:cop) { described_class.new }
 
   described_class::NAMESPACES.each do |var|
 

--- a/spec/rubocop/cop/sketchup_requirements/sketchup_extension_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/sketchup_extension_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupRequirements::SketchupExtension do
-
-  subject(:cop) { described_class.new(config) }
+describe RuboCop::Cop::SketchupRequirements::SketchupExtension, :config do
 
   context 'Default source path' do
 
@@ -141,8 +139,6 @@ describe RuboCop::Cop::SketchupRequirements::SketchupExtension do
   end # context
 
   context 'Custom source path' do
-
-    subject(:cop) { described_class.new(config) }
 
     let(:config) do
       rubocop_config = {

--- a/spec/rubocop/cop/sketchup_requirements/sketchup_require_spec.rb
+++ b/spec/rubocop/cop/sketchup_requirements/sketchup_require_spec.rb
@@ -99,7 +99,6 @@ describe RuboCop::Cop::SketchupRequirements::SketchupRequire do
 
   end
 
-
   context 'encrypted extension' do
 
     let(:config) do
@@ -142,7 +141,6 @@ describe RuboCop::Cop::SketchupRequirements::SketchupRequire do
 
   end
 
-
   context 'SketchupExtension.new' do
 
     it 'registers an offense when using `SketchupExtension.new` with file extension' do
@@ -170,7 +168,6 @@ describe RuboCop::Cop::SketchupRequirements::SketchupRequire do
     end
 
   end
-
 
   context 'requiring files from Tools folder' do
 

--- a/spec/rubocop/cop/sketchup_suggestions/add_group_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/add_group_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupSuggestions::AddGroup do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupSuggestions::AddGroup, :config do
 
   it 'registers an offense when creating groups out of existing entities' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_suggestions/compatibility_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/compatibility_spec.rb
@@ -2,11 +2,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupSuggestions::Compatibility do
+describe RuboCop::Cop::SketchupSuggestions::Compatibility, :config do
 
   context 'incompatible features' do
-
-    subject(:cop) { described_class.new(config) }
 
     let(:config) do
       sketchup_version_config('SketchUp 6')
@@ -96,10 +94,7 @@ describe RuboCop::Cop::SketchupSuggestions::Compatibility do
 
   end
 
-
   context 'compatible features' do
-
-    subject(:cop) { described_class.new(config) }
 
     let(:config) do
       sketchup_version_config('SketchUp 2018')

--- a/spec/rubocop/cop/sketchup_suggestions/dc_internals_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/dc_internals_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupSuggestions::DynamicComponentInternals do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupSuggestions::DynamicComponentInternals, :config do
 
   described_class::DC_GLOBALS.each do |var|
 

--- a/spec/rubocop/cop/sketchup_suggestions/file_encoding_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/file_encoding_spec.rb
@@ -4,8 +4,6 @@ require 'spec_helper'
 
 describe RuboCop::Cop::SketchupSuggestions::FileEncoding, :config do
 
-  subject(:cop) { described_class.new }
-
   it 'registers an offense when using __dir__ in method parameters' do
     expect_offense(<<~RUBY)
       file = File.join(__dir__, "hello.rb")

--- a/spec/rubocop/cop/sketchup_suggestions/model_entities_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/model_entities_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupSuggestions::ModelEntities do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupSuggestions::ModelEntities, :config do
 
   it 'registers an offense when fetching model.entities' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_suggestions/monkey_patched_api_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/monkey_patched_api_spec.rb
@@ -2,10 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupSuggestions::MonkeyPatchedApi do
-
-  subject(:cop) { described_class.new }
-
+describe RuboCop::Cop::SketchupSuggestions::MonkeyPatchedApi, :config do
 
   context 'Shipped Extensions API monkey-patching' do
 
@@ -32,7 +29,6 @@ describe RuboCop::Cop::SketchupSuggestions::MonkeyPatchedApi do
 
   end # context
 
-
   context 'Shipped Extensions API monkey-patching with variable name context' do
 
     it 'registers an register an offense when using monkey-patched method' do
@@ -53,7 +49,6 @@ describe RuboCop::Cop::SketchupSuggestions::MonkeyPatchedApi do
     end
 
   end # context
-
 
   context 'Shipped Extensions API monkey-patching with instance variable name context' do
 
@@ -93,7 +88,6 @@ describe RuboCop::Cop::SketchupSuggestions::MonkeyPatchedApi do
     end
 
   end # context
-
 
   context 'Shipped Extensions API monkey-patching with class variable name context' do
 

--- a/spec/rubocop/cop/sketchup_suggestions/operation_name_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/operation_name_spec.rb
@@ -4,8 +4,6 @@ require 'spec_helper'
 
 describe RuboCop::Cop::SketchupSuggestions::OperationName, :config do
 
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'Max' => 25 } }
 
   it 'registers an offense when operations name is too long' do
@@ -14,7 +12,6 @@ describe RuboCop::Cop::SketchupSuggestions::OperationName, :config do
                                                       ^^^^^^ Operation names should not be short and concise. [31/25]
     RUBY
   end
-
 
   context 'Max: 32' do
 
@@ -29,7 +26,6 @@ describe RuboCop::Cop::SketchupSuggestions::OperationName, :config do
     end
 
   end
-
 
   it 'does not register an offense when operation is transparent' do
     expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_suggestions/sketchup_find_support_file_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/sketchup_find_support_file_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupSuggestions::SketchupFindSupportFile do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupSuggestions::SketchupFindSupportFile, :config do
 
   it 'registers an offense when using Sketchup.find_support_file with a string literal' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_suggestions/sleep_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/sleep_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupSuggestions::Sleep do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupSuggestions::Sleep, :config do
 
   it 'registers an offense when using kernel `sleep`' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_suggestions/tool_drawing_bounds_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/tool_drawing_bounds_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupSuggestions::ToolDrawingBounds do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupSuggestions::ToolDrawingBounds, :config do
 
   context 'with a draw method' do
 
@@ -17,7 +15,6 @@ describe RuboCop::Cop::SketchupSuggestions::ToolDrawingBounds do
         end
       RUBY
     end
-
 
     it 'does not register an offense when `getExtents` is implemented' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/sketchup_suggestions/tool_invalidate_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/tool_invalidate_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupSuggestions::ToolInvalidate do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupSuggestions::ToolInvalidate, :config do
 
   context 'with a draw method' do
 

--- a/spec/rubocop/cop/sketchup_suggestions/tool_user_input_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/tool_user_input_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupSuggestions::ToolUserInput do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupSuggestions::ToolUserInput, :config do
 
   context 'with a onUserText method' do
 

--- a/spec/rubocop/cop/sketchup_suggestions/toolbar_timer_spec.rb
+++ b/spec/rubocop/cop/sketchup_suggestions/toolbar_timer_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::SketchupSuggestions::ToolbarTimer do
-
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::SketchupSuggestions::ToolbarTimer, :config do
 
   it 'registers an offense when calling .restore within a timer' do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/sketchup/sketchup_target_range_spec.rb
+++ b/spec/rubocop/sketchup/sketchup_target_range_spec.rb
@@ -57,7 +57,6 @@ describe RuboCop::SketchUp::SketchUpTargetRange do
 
   end # context 'cop with minimum sketchup target'
 
-
   context 'cop with maximum sketchup target' do
 
     let(:fake_cop) do
@@ -108,7 +107,6 @@ describe RuboCop::SketchUp::SketchUpTargetRange do
     end # context
 
   end # context 'cop with maximum sketchup target'
-
 
   context 'cop with minimum and maximum sketchup target' do
 


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop/issues/11817.

The test code is updated with the following command to resolve the issue:

```console
$ bundle exec rubocop --require rubocop/cop/internal_affairs \
  --only InternalAffairs/RedundantDescribedClassAsSubject,Layout/EmptyLines -a spec
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
