### PR TITLE
Rubocop expects formatters to be a string

### DIFF
--- a/lib/rubocop-sketchup.rb
+++ b/lib/rubocop-sketchup.rb
@@ -26,8 +26,8 @@ RuboCop::SketchUp::Inject.defaults!
 # formatters. Naughty! Naughty!
 class RuboCop::Formatter::FormatterSet
   formatters = BUILTIN_FORMATTERS_FOR_KEYS.dup
-  formatters['extension_review'] =
-      RuboCop::Formatter::ExtensionReviewFormatter
+  formatters['extension_review'] = 'ExtensionReviewFormatter'
+
   verbose = $VERBOSE
   begin
     $VERBOSE = nil


### PR DESCRIPTION
I found that this change is needed using ruby 3.2.2 as rubocop expects `BUILTIN_FORMATTERS_FOR_KEYS` to be a map of keys to strings and not to classes, see [`rubocop-1.63.5\lib\rubocop\formatter\formatter_set.rb`](https://github.com/rubocop/rubocop/blob/master/lib/rubocop/formatter/formatter_set.rb#L11)

Without this change I get the error "no implicit conversion of Class into String" when trying to run `rubocop -d -f extension_review -o report.html`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: http://chris.beams.io/posts/git-commit/
